### PR TITLE
Return promises for all methods instead of sending messages

### DIFF
--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -1,14 +1,14 @@
+import Promise from 'bluebird';
+
 import { eightball } from '../../data';
 import T from '../../translate';
 
 
-function eightBall(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(`${T('8ball_usage', lang)}\nhttp://i.imgur.com/PcXHbt6.gif`);
-  } else {
-    const rand = Math.floor(Math.random() * eightball.length);
-    e.message.channel.sendMessage(`🎱 **${eightball[rand]}** 🎱`);
-  }
+function eightBall(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(`${T('8ball_usage', lang)}\nhttp://i.imgur.com/PcXHbt6.gif`);
+
+  const rand = Math.floor(Math.random() * eightball.length);
+  return Promise.resolve(`🎱 **${eightball[rand]}** 🎱`);
 }
 
 export default {

--- a/src/commands/fun/animals.js
+++ b/src/commands/fun/animals.js
@@ -3,12 +3,10 @@ import _request from 'request';
 import R from 'ramda';
 
 import { subCommands as helpText } from '../help';
-import sentry from '../../sentry';
-
 
 const request = Promise.promisify(_request);
 
-function cat(client, e, suffix) {
+function cat(client, evt, suffix) {
   let count = 1;
   if (suffix && suffix.split(' ')[0] === 'bomb') {
     count = Number(suffix.split(' ')[1]) || 5;
@@ -21,21 +19,16 @@ function cat(client, e, suffix) {
     json: true
   };
 
-  Promise.resolve(R.repeat('cat', count))
+  return Promise.resolve(R.repeat('cat', count))
     .map(() => {
       return request(options)
         .then(R.path(['body', 'file']))
         .then(encodeURI);
     })
-    .then(R.join('\n'))
-    .then(text => e.message.channel.sendMessage(text))
-    .catch(err => {
-      sentry(err, 'images', 'cat');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then(R.join('\n'));
 }
 
-function pug(client, e, suffix) {
+function pug(client, evt, suffix) {
   let count = 1;
   if (suffix && suffix.split(' ')[0] === 'bomb') {
     count = Number(suffix.split(' ')[1]) || 5;
@@ -52,17 +45,12 @@ function pug(client, e, suffix) {
     json: true
   };
 
-  request(options)
+  return request(options)
     .then(R.path(['body', 'pugs']))
-    .then(R.join('\n'))
-    .then(text => e.message.channel.sendMessage(text))
-    .catch(err => {
-      sentry(err, 'images', 'pug');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then(R.join('\n'));
 }
 
-function snake(client, e, suffix) {
+function snake(client, evt, suffix) {
   let count = 1;
   if (suffix && suffix.split(' ')[0] === 'bomb') {
     count = Number(suffix.split(' ')[1]) || 5;
@@ -75,22 +63,17 @@ function snake(client, e, suffix) {
     json: true
   };
 
-  Promise.resolve(R.repeat('snake', count))
+  return Promise.resolve(R.repeat('snake', count))
     .map(() => {
       return request(options)
         .then(R.path(['body', 'file']))
         .then(encodeURI);
     })
-    .then(R.join('\n'))
-    .then(text => e.message.channel.sendMessage(text))
-    .catch(err => {
-      sentry(err, 'images', 'snake');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then(R.join('\n'));
 }
 
-function animals(client, e, suffix, lang) {
-  e.message.channel.sendMessage(helpText(client, e, 'animals', lang));
+function animals(client, evt, suffix, lang) {
+  return helpText(client, evt, 'animals', lang);
 }
 
 export default {

--- a/src/commands/fun/chat.js
+++ b/src/commands/fun/chat.js
@@ -1,36 +1,36 @@
+import Promise from 'bluebird';
 import Cleverbot from 'cleverbot-node';
 import ent from 'entities';
 import nconf from 'nconf';
 
-import sentry from '../../sentry';
 import T from '../../translate';
 
 
 const clever = new Cleverbot(nconf.get('CLEVERBOT_API_NAME'), nconf.get('CLEVERBOT_API_KEY'));
 
-function chat(client, e, suffix, lang) {
+function chat(client, evt, suffix, lang) {
   if (!nconf.get('CLEVERBOT_API_NAME') || !nconf.get('CLEVERBOT_API_KEY')) {
-    e.message.channel.sendMessage(T('chat_setup', lang));
-    return;
+    return Promise.resolve(T('chat_setup', lang));
   }
 
   if (!suffix) suffix = 'Hello.';
 
-  Cleverbot.prepare(() => {
-    try {
-      clever.write(suffix, (response) => {
-        if (/\|/g.test(response.message)) {
-          response.message = response.message.replace(/\|/g, '\\u');
-          response.message = response.message.replace(/\\u([\d\w]{4})/gi, (match, grp) => {
-            return String.fromCharCode(parseInt(grp, 16));
-          });
-        }
-        e.message.channel.sendMessage(ent.decodeHTML(response.message));
-      });
-    } catch (err) {
-      sentry(err, 'chat');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    }
+  return new Promise((resolve, reject) => {
+    Cleverbot.prepare(() => {
+      try {
+        clever.write(suffix, (response) => {
+          if (/\|/g.test(response.message)) {
+            response.message = response.message.replace(/\|/g, '\\u');
+            response.message = response.message.replace(/\\u([\d\w]{4})/gi, (match, grp) => {
+              return String.fromCharCode(parseInt(grp, 16));
+            });
+          }
+          resolve(ent.decodeHTML(response.message));
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
   });
 }
 

--- a/src/commands/fun/coin.js
+++ b/src/commands/fun/coin.js
@@ -1,10 +1,9 @@
+import Promise from 'bluebird';
+
 function coin(client, e) {
   const number = Math.floor(Math.random() * 2) + 1;
-  if (number === 1) {
-    e.message.channel.uploadFile('./images/Heads.png');
-  } else {
-    e.message.channel.uploadFile('./images/Tails.png');
-  }
+  if (number === 1) return Promise.resolve({upload: './images/Heads.png'});
+  return Promise.resolve({upload: './images/Tails.png'});
 }
 
 export default {

--- a/src/commands/fun/comics.js
+++ b/src/commands/fun/comics.js
@@ -4,58 +4,42 @@ import _request from 'request';
 import R from 'ramda';
 
 import { subCommands as helpText } from '../help';
-import sentry from '../../sentry';
 
 
 const request = Promise.promisify(_request);
 
 // Cyanide and Happiness
-function cah(client, e) {
-  request('http://explosm.net/comics/random/')
+function cah() {
+  return request('http://explosm.net/comics/random/')
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#main-comic').attr('src'))
-    .then(url => e.message.channel.sendMessage(`http:${url}`))
-    .catch(err => {
-      sentry(err, 'comics', 'cah');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => `http:${$('#main-comic').attr('src')}`);
 }
 
 // Saturday Morning Breakfast Cereal
-function smbc(client, e) {
-  request('http://www.smbc-comics.com/')
+function smbc() {
+  return request('http://www.smbc-comics.com/')
     .then(R.prop('body'))
     .then(cheerio.load)
     .then($ => $('.random').first().attr('href'))
     .then(url => request(`http://www.smbc-comics.com/${url}`))
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#comic').attr('src'))
-    .then(url => e.message.channel.sendMessage(`http://www.smbc-comics.com/${url}`))
-    .catch(err => {
-      sentry(err, 'comics', 'smbc');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => `http://www.smbc-comics.com/${$('#comic').attr('src')}`);
 }
 
 // Amazing Super Powers
-function amazingSuperPowers(client, e) {
-  request('http://www.amazingsuperpowers.com/?randomcomic&nocache=1')
+function amazingSuperPowers() {
+  return request('http://www.amazingsuperpowers.com/?randomcomic&nocache=1')
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#comic-1').find('img').first().attr('src'))
-    .then(url => e.message.channel.sendMessage(url))
-    .catch(err => {
-      sentry(err, 'comics', 'amazingSuperPowers');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => $('#comic-1').find('img').first().attr('src'));
 }
 
 // Awkward Zombie
-function awkwardZombie(client, e) {
+function awkwardZombie() {
   function _makeRequest(url) {
-    let options = {
+    const options = {
       url: `http://www.awkwardzombie.com/${url}`,
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36'
@@ -67,37 +51,27 @@ function awkwardZombie(client, e) {
       .then(cheerio.load);
   }
 
-  _makeRequest('index.php?page=1')
+  return _makeRequest('index.php?page=1')
     .then($ => {
-      let table = $('#archive_table').find('tr');
-      let rand = Math.floor(Math.random() * table.length);
-      let url = table.eq(rand).find('a').first().attr('href');
+      const table = $('#archive_table').find('tr');
+      const rand = Math.floor(Math.random() * table.length);
+      const url = table.eq(rand).find('a').first().attr('href');
       return _makeRequest(url);
     })
-    .then($ => $('#comic').find('img').first().attr('src'))
-    .then(url => e.message.channel.sendMessage(url))
-    .catch(err => {
-      sentry(err, 'comics', 'awkwardZombie');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => $('#comic').find('img').first().attr('src'));
 }
 
 // Chain Saw Suit
-function chainsawsuit(client, e) {
-  request('http://chainsawsuit.com/random/?random&nocache=1')
+function chainsawsuit() {
+  return request('http://chainsawsuit.com/random/?random&nocache=1')
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#comic').find('img').first().attr('src'))
-    .then(url => e.message.channel.sendMessage(url))
-    .catch(err => {
-      sentry(err, 'comics', 'chainsawsuit');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => $('#comic').find('img').first().attr('src'));
 }
 
 // Dog House Diaries
-function dogHouseDiaries(client, e) {
-  request('http://thedoghousediaries.com/')
+function dogHouseDiaries() {
+  return request('http://thedoghousediaries.com/')
     .then(R.prop('body'))
     .then(cheerio.load)
     .then($ => $('#randomlink').attr('href'))
@@ -105,29 +79,20 @@ function dogHouseDiaries(client, e) {
     .then(R.prop('body'))
     .then(cheerio.load)
     .then($ => $('#imgdiv').find('img').first().attr('src').replace('\n', ''))
-    .then(url => e.message.channel.sendMessage(`http://thedoghousediaries.com/${url}`))
-    .catch(err => {
-      sentry(err, 'comics', 'dogHouseDiaries');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then(url => `http://thedoghousediaries.com/${url}`);
 }
 
 // The Oatmeal
-function theOatmeal(client, e) {
-  request('http://theoatmeal.com/feed/random')
+function theOatmeal() {
+  return request('http://theoatmeal.com/feed/random')
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#comic').find('img').first().attr('src'))
-    .then(url => e.message.channel.sendMessage(url))
-    .catch(err => {
-      sentry(err, 'comics', 'theOatmeal');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => $('#comic').find('img').first().attr('src'));
 }
 
 // xkcd
-function xkcd(client, e) {
-  let options = {
+function xkcd() {
+  const options = {
     url: 'https://c.xkcd.com/random/comic/',
     rejectUnauthorized: false,
     headers: {
@@ -135,18 +100,13 @@ function xkcd(client, e) {
     }
   };
 
-  request(options)
+  return request(options)
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('#comic').find('img').first().attr('src'))
-    .then(url => e.message.channel.sendMessage(`https:${url}`))
-    .catch(err => {
-      sentry(err, 'comics', 'xkcd');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => `https:${$('#comic').find('img').first().attr('src')}`);
 }
 
-function randomComic(client, e) {
+function randomComic() {
   // Add all commands here so a random one can be selected
   const commands = [
     cah,
@@ -159,48 +119,48 @@ function randomComic(client, e) {
     xkcd
   ];
   const rand = Math.floor(Math.random() * commands.length);
-  commands[rand](client, e);
+  return commands[rand]();
 }
 
-function comics(client, e, suffix, lang) {
+function comics(client, evt, suffix, lang) {
   suffix = suffix.toLowerCase();
-  if (suffix === 'random') return randomComic(client, e);
+  if (suffix === 'random') return randomComic();
 
   // Cyanide and Happiness
-  if (suffix === 'cah') return cah(client, e);
-  if (suffix === 'cyanide') return cah(client, e);
-  if (suffix === 'cyanide and happiness') return cah(client, e);
+  if (suffix === 'cah') return cah();
+  if (suffix === 'cyanide') return cah();
+  if (suffix === 'cyanide and happiness') return cah();
 
   // Saturday Morning Breakfast Cereal
-  if (suffix === 'smbc') return smbc(client, e);
-  if (suffix === 'saturday morning breakfast cereal') return smbc(client, e);
+  if (suffix === 'smbc') return smbc();
+  if (suffix === 'saturday morning breakfast cereal') return smbc();
 
   // Amazing Super Powers
-  if (suffix === 'asp') return amazingSuperPowers(client, e);
-  if (suffix === 'amazing super powers') return amazingSuperPowers(client, e);
+  if (suffix === 'asp') return amazingSuperPowers();
+  if (suffix === 'amazing super powers') return amazingSuperPowers();
 
   // Awkward Zombie
-  if (suffix === 'az') return awkwardZombie(client, e);
-  if (suffix === 'awkward zombie') return awkwardZombie(client, e);
+  if (suffix === 'az') return awkwardZombie();
+  if (suffix === 'awkward zombie') return awkwardZombie();
 
   // chainsawsuit
-  if (suffix === 'css') return chainsawsuit(client, e);
-  if (suffix === 'chainsawsuit') return chainsawsuit(client, e);
-  if (suffix === 'chain saw suit') return chainsawsuit(client, e);
+  if (suffix === 'css') return chainsawsuit();
+  if (suffix === 'chainsawsuit') return chainsawsuit();
+  if (suffix === 'chain saw suit') return chainsawsuit();
 
   // Dog House Diaries
-  if (suffix === 'dhd') return dogHouseDiaries(client, e);
-  if (suffix === 'doghousdiaries') return dogHouseDiaries(client, e);
-  if (suffix === 'dog house diaries') return dogHouseDiaries(client, e);
+  if (suffix === 'dhd') return dogHouseDiaries();
+  if (suffix === 'doghousdiaries') return dogHouseDiaries();
+  if (suffix === 'dog house diaries') return dogHouseDiaries();
 
   // The Oatmeal
-  if (suffix === 'to') return theOatmeal(client, e);
-  if (suffix.indexOf('oatmeal') > -1) return theOatmeal(client, e);
+  if (suffix === 'to') return theOatmeal();
+  if (suffix.indexOf('oatmeal') > -1) return theOatmeal();
 
   // xkcd
-  if (suffix === 'xkcd') return xkcd(client, e);
+  if (suffix === 'xkcd') return xkcd();
 
-  return e.message.channel.sendMessage(helpText(client, e, 'comics', lang));
+  return helpText(client, evt, 'comics', lang);
 }
 
 export default {

--- a/src/commands/fun/decide.js
+++ b/src/commands/fun/decide.js
@@ -1,8 +1,10 @@
+import Promise from 'bluebird';
+
 import { choices } from '../../data';
 import T from '../../translate';
 
 
-function decide(client, e, suffix, lang) {
+function decide(client, evt, suffix, lang) {
   function multipleDecide(options) {
     const selected = options[Math.floor(Math.random() * options.length)];
     if (!selected) return multipleDecide(options);
@@ -11,11 +13,9 @@ function decide(client, e, suffix, lang) {
 
   const split = suffix.split(` ${T('decide_split', lang)} `);
   const rand = Math.floor(Math.random() * choices.length);
-  if (split.length > 1) {
-    e.message.channel.sendMessage(`${choices[rand]} **${multipleDecide(split)}**`);
-  } else {
-    e.message.channel.sendMessage(T('decide_usage', lang));
-  }
+  if (split.length > 1) return Promise.resolve(`${choices[rand]} **${multipleDecide(split)}**`);
+
+  return Promise.resolve(T('decide_usage', lang));
 }
 
 export default {

--- a/src/commands/fun/meme.js
+++ b/src/commands/fun/meme.js
@@ -1,38 +1,31 @@
+import Promise from 'bluebird';
 import Imgflipper from 'imgflipper';
 import nconf from 'nconf';
 
-import sentry from '../../sentry';
 import T from '../../translate';
-
 import { memes } from '../../data';
 
 
 const imgflipper = new Imgflipper(nconf.get('IMGFLIP_USERNAME'), nconf.get('IMGFLIP_PASSWORD'));
+const generateMeme = Promise.promisify(imgflipper.generateMeme);
 
-function meme(client, e, suffix, lang) {
-  if (!nconf.get('IMGFLIP_USERNAME') || !nconf.get('IMGFLIP_PASSWORD')) {
-    e.message.channel.sendMessage(T('meme_setup', lang));
-    return;
-  }
+function meme(client, evt, suffix, lang) {
+  if (!nconf.get('IMGFLIP_USERNAME') || !nconf.get('IMGFLIP_PASSWORD')) return Promise.resolve(T('meme_setup', lang));
+  if (!suffix) return Promise.resolve(T('meme_setup', lang));
 
-  if (!suffix) {
-    e.message.channel.sendMessage(T('meme_usage', lang));
-    return;
-  }
   const tags = suffix.split('"');
   const memetype = tags[0].trim();
 
-  // Still send blank meme, but also send usage message.
-  if (!tags[1] && !tags[3]) e.message.channel.sendMessage(T('meme_usage', lang));
-
-  imgflipper.generateMeme(memes[memetype], tags[1] ? tags[1] : ' ', tags[3] ? tags[3] : ' ', (err, image) => {
-    if (err) {
-      if (err.message !== 'No texts supplied') sentry(err, 'meme');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    } else {
-      e.message.channel.sendMessage(image);
-    }
-  });
+  return generateMeme(memes[memetype], tags[1] ? tags[1] : ' ', tags[3] ? tags[3] : ' ')
+    .then(image => {
+      // Still send blank meme, but also send usage message.
+      if (!tags[1] && !tags[3]) return [T('meme_usage', lang), image];
+      return image;
+    })
+    .catch(err => {
+      if (err.message !== 'No texts supplied') throw err;
+      return `Error: ${err.message}`;
+    });
 }
 
 export default {

--- a/src/commands/fun/responses.js
+++ b/src/commands/fun/responses.js
@@ -1,31 +1,24 @@
+import Promise from 'bluebird';
+
 import { drama as _drama, emoji as _emoji, quotes } from '../../data';
 
 
-function drama(client, e, suffix) {
+function drama(client, evt, suffix) {
   const rand = Math.floor(Math.random() * _drama.length);
-  if (suffix && suffix >= 0 && suffix <= (_drama.length - 1)) {
-    e.message.channel.sendMessage(_drama[suffix]);
-  } else {
-    e.message.channel.sendMessage(_drama[rand]);
-  }
+  if (suffix && suffix >= 0 && suffix <= (_drama.length - 1)) return Promise.resolve(_drama[suffix]);
+  return Promise.resolve(_drama[rand]);
 }
 
-function emoji(client, e, suffix) {
+function emoji(client, evt, suffix) {
   const rand = Math.floor(Math.random() * _emoji.length);
-  if (suffix && suffix >= 0 && suffix <= (_emoji.length - 1)) {
-    e.message.channel.sendMessage(_emoji[suffix]);
-  } else {
-    e.message.channel.sendMessage(_emoji[rand]);
-  }
+  if (suffix && suffix >= 0 && suffix <= (_emoji.length - 1)) return Promise.resolve(_emoji[suffix]);
+  return Promise.resolve(_emoji[rand]);
 }
 
-function quote(client, e, suffix) {
+function quote(client, evt, suffix) {
   const rand = Math.floor(Math.random() * quotes.length);
-  if (suffix && suffix >= 0 && suffix <= (quotes.length - 1)) {
-    e.message.channel.sendMessage(quotes[suffix]);
-  } else {
-    e.message.channel.sendMessage(quotes[rand]);
-  }
+  if (suffix && suffix >= 0 && suffix <= (quotes.length - 1)) return Promise.resolve(quotes[suffix]);
+  return Promise.resolve(quotes[rand]);
 }
 
 export default {

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -1,7 +1,8 @@
+import Promise from 'bluebird';
 import R from 'ramda';
 
 
-function roll(client, e, suffix) {
+function roll(client, evt, suffix) {
   let times = suffix.split(' ')[0];
   let sides = suffix.split(' ')[1];
 
@@ -9,11 +10,11 @@ function roll(client, e, suffix) {
   if (!sides) sides = 6;
 
   if (isNaN(times) || isNaN(sides)) {
-    return e.message.channel.sendMessage(`${e.message.author.mention} rolled ${suffix}\nUsage: **\`!roll\`** \`times\` \`sides\``);
+    return Promise.resolve(`${evt.message.author.mention} rolled ${suffix}\nUsage: **\`!roll\`** \`times\` \`sides\``);
   }
 
   if (times > 1000 || sides > 1000000) {
-    return e.message.channel.sendMessage(`${e.message.author.mention} I\'m too high to calculate that high number.`);
+    return Promise.resolve(`${evt.message.author.mention} I\'m too high to calculate that high number.`);
   }
 
   let total = 0;
@@ -25,16 +26,15 @@ function roll(client, e, suffix) {
 
   const average = total / times;
 
-  let return_text = `${e.message.author.mention} rolled a ${sides} sided dice ${times} times for a total of **${total}** (average: ${average}):\n${msg_array}`;
-  if (return_text.length >= 1999) {
-    return e.message.channel.sendMessage(`${e.message.author.mention} I\'m too high to calculate that high number.`);
-  }
 
-  e.message.channel.sendMessage(return_text);
-
+  let return_text = `${evt.message.author.mention} rolled a ${sides} sided dice ${times} times for a total of **${total}** (average: ${average}):\n${msg_array}`;
   // Attempt clearing RAM early
-  return_text = null;
   msg_array = null;
+
+  if (return_text.length >= 1999) {
+    return Promise.resolve(`${evt.message.author.mention} I\'m too high to calculate that high number.`);
+  }
+  return Promise.resolve(return_text);
 }
 
 export default {

--- a/src/commands/fun/translate.js
+++ b/src/commands/fun/translate.js
@@ -1,42 +1,26 @@
 import Promise from 'bluebird';
 import cheerio from 'cheerio';
-import gizoogle from 'gizoogle';
 import leetify from 'leet';
-import _request from 'request';
 import R from 'ramda';
 
 import { subCommands as helpText } from '../help';
-import sentry from '../../sentry';
 import T from '../../translate';
 
+const request = Promise.promisify(require('request'));
+const gizoogle = Promise.promisifyAll(require('gizoogle'));
 
-const request = Promise.promisify(_request);
-
-function leet(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(T('leet_usage', lang));
-    return;
-  }
-  let translation = leetify.convert(suffix);
-  e.message.channel.sendMessage(translation);
+function leet(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(T('leet_usage', lang));
+  return Promise.resolve(leetify.convert(suffix));
 }
 
-function snoop(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(T('snoop_usage', lang));
-    return;
-  }
-  gizoogle.string(suffix, (err, translation) => {
-    if (err) sentry(err, 'translate', 'snoop');
-    e.message.channel.sendMessage(translation);
-  });
+function snoop(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(T('snoop_usage', lang));
+  return gizoogle.stringAsync(suffix);
 }
 
-function yoda(client, e, phrase, lang) {
-  if (!phrase) {
-    e.message.channel.sendMessage(T('yoda_usage', lang));
-    return;
-  }
+function yoda(client, evt, phrase, lang) {
+  if (!phrase) return Promise.resolve(T('yoda_usage', lang));
 
   const options = {
     url: 'http://www.yodaspeak.co.uk/index.php',
@@ -47,19 +31,14 @@ function yoda(client, e, phrase, lang) {
     }
   };
 
-  request(options)
+  return request(options)
     .then(R.prop('body'))
     .then(cheerio.load)
-    .then($ => $('textarea[name="YodaSpeak"]').first().text())
-    .then(text => e.message.channel.sendMessage(text))
-    .catch(err => {
-      sentry(err, 'translate', 'yoda');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+    .then($ => $('textarea[name="YodaSpeak"]').first().text());
 }
 
-function translate(client, e, suffix, lang) {
-  e.message.channel.sendMessage(helpText(client, e, 'translate', lang));
+function translate(client, evt, suffix, lang) {
+  return helpText(client, evt, 'translate', lang);
 }
 
 export default {

--- a/src/commands/games/dota2.js
+++ b/src/commands/games/dota2.js
@@ -128,7 +128,7 @@ function counters(suffix) {
     .then(R.join('\n'));
 }
 
-function impact(client, e) {
+function impact() {
   const options = {
     url: `http://www.dotabuff.com/heroes/impact`,
     headers: {
@@ -212,7 +212,7 @@ function commands(client, e, suffix, lang) {
   if (command === 'best') return best(suffix);
   if (command === 'counter') return counters(suffix);
   if (command === 'counters') return counters(suffix);
-  if (command === 'impact') return impact(client, e);
+  if (command === 'impact') return impact();
   if (command === 'item') return items(suffix);
   if (command === 'items') return items(suffix);
   if (command === 'matchup') return counters(suffix);

--- a/src/commands/games/leagueoflegends/index.js
+++ b/src/commands/games/leagueoflegends/index.js
@@ -5,27 +5,27 @@ import { serverStatus, matchDetails } from './riot';
 
 
 export default {
-  lol: (client, e, suffix, lang) => {
+  lol: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
 
-    if (command === 'ban') return bans(client, e);
-    if (command === 'bans') return bans(client, e);
-    if (command === 'best') return best(client, e, suffix);
-    if (command === 'build') return items(client, e, suffix);
-    if (command === 'builds') return items(client, e, suffix);
-    if (command === 'counter') return counters(client, e, suffix);
-    if (command === 'counters') return counters(client, e, suffix);
-    if (command === 'item') return items(client, e, suffix);
-    if (command === 'items') return items(client, e, suffix);
-    if (command === 'match') return matchDetails(client, e, suffix);
-    if (command === 'skill') return skills(client, e, suffix);
-    if (command === 'skills') return skills(client, e, suffix);
-    if (command === 'server') return serverStatus(client, e, suffix);
-    if (command === 'server-status') return serverStatus(client, e, suffix);
-    if (command === 'servers') return serverStatus(client, e, suffix);
-    if (command === 'serverstatus') return serverStatus(client, e, suffix);
-    if (command === 'status') return serverStatus(client, e, suffix);
-    return helpText(client, e, 'lol', lang);
+    if (command === 'ban') return bans();
+    if (command === 'bans') return bans();
+    if (command === 'best') return best(suffix, lang);
+    if (command === 'build') return items(suffix, lang);
+    if (command === 'builds') return items(suffix, lang);
+    if (command === 'counter') return counters(suffix, lang);
+    if (command === 'counters') return counters(suffix, lang);
+    if (command === 'item') return items(suffix, lang);
+    if (command === 'items') return items(suffix, lang);
+    if (command === 'match') return matchDetails(client, evt, suffix, lang);
+    if (command === 'skill') return skills(suffix, lang);
+    if (command === 'skills') return skills(suffix, lang);
+    if (command === 'server') return serverStatus(suffix, lang);
+    if (command === 'server-status') return serverStatus(suffix, lang);
+    if (command === 'servers') return serverStatus(suffix, lang);
+    if (command === 'serverstatus') return serverStatus(suffix, lang);
+    if (command === 'status') return serverStatus(suffix, lang);
+    return helpText(client, evt, 'lol', lang);
   }
 };
 

--- a/src/commands/help/index.js
+++ b/src/commands/help/index.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import chalk from 'chalk';
 import nconf from 'nconf';
 import path from 'path';
@@ -60,7 +61,8 @@ export function subCommands(client, e, method, lang) {
     const header_text = T(help_parameters[method].header_text, lang);
     text = `${header_text}\n\n${text}`;
   }
-  e.message.channel.sendMessage(text);
+
+  return Promise.resolve(text);
 }
 
 // E.g. !help useful
@@ -92,7 +94,7 @@ function helpCategory(client, e, category, lang = 'en') {
       return client.Users.get(e.message.author.id).openDM().then(dm => dm.sendMessage(R.join('\n', R.reject(R.isNil, commands_text))));
     }, R.splitEvery(10)(text));
   } else {
-    return e.message.channel.sendMessage(R.join('\n', R.reject(R.isNil, text)));
+    return Promise.resolve(R.join('\n', R.reject(R.isNil, text)));
   }
 }
 
@@ -125,7 +127,7 @@ function help(client, e, suffix, lang) {
     text.push(command_text);
   }, categories.help);
 
-  return e.message.channel.sendMessage(R.join('\n', text));
+  return Promise.resolve(R.join('\n', text));
 }
 
 function memelist(client, e, suffix) {

--- a/src/commands/other.js
+++ b/src/commands/other.js
@@ -1,38 +1,21 @@
+import Promise from 'bluebird';
 import path from 'path';
 
 
 export default {
-  ayylmao: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/m7NaGVx.gif');
-    e.message.channel.uploadFile(path.join(__dirname, '../../images/Ayylmao.png'));
-  },
-  chillenmyb: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/Qh75Dsi.jpg');
-  },
-  endall: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/SNmMCQV.png');
-  },
-  feelsgoodman: (client, e) => {
-    e.message.channel.uploadFile(path.join(__dirname, '../../images/Feelsgoodman.png'));
-  },
-  jpeg: (client, e) => {
-    e.message.channel.sendMessage('https://www.youtube.com/watch?v=QEzhxP-pdos');
-  },
-  kappa: (client, e) => {
-    e.message.channel.uploadFile(path.join(__dirname, '../../images/Kappa.png'));
-  },
-  kappahd: (client, e) => {
-    e.message.channel.uploadFile(path.join(__dirname, '../../images/Kappahd.png'));
-  },
-  skeltal: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/ZX79Q4S.gif');
-  },
-  starwars4: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/l9VKWWF.gif');
-  },
-  starwars5: (client, e) => {
-    e.message.channel.sendMessage('http://i.imgur.com/eCpwo6J.gif');
-  }
+  ayylmao: () => Promise.resolve([
+    'http://i.imgur.com/m7NaGVx.gif',
+    {upload: path.join(__dirname, '../../images/Ayylmao.png')}
+  ]),
+  chillenmyb: () => Promise.resolve('http://i.imgur.com/Qh75Dsi.jpg'),
+  endall: () => Promise.resolve('http://i.imgur.com/SNmMCQV.png'),
+  feelsgoodman: () => Promise.resolve({upload: path.join(__dirname, '../../images/Feelsgoodman.png')}),
+  jpeg: () => Promise.resolve('https://www.youtube.com/watch?v=QEzhxP-pdos'),
+  kappa: () => Promise.resolve({upload: path.join(__dirname, '../../images/Kappa.png')}),
+  kappahd: () => Promise.resolve({upload: path.join(__dirname, '../../images/Kappahd.png')}),
+  skeltal: () => Promise.resolve('http://i.imgur.com/ZX79Q4S.gif'),
+  starwars4: () => Promise.resolve('http://i.imgur.com/l9VKWWF.gif'),
+  starwars5: () => Promise.resolve('http://i.imgur.com/eCpwo6J.gif')
 };
 
 export const help = {

--- a/src/commands/useful/appearin.js
+++ b/src/commands/useful/appearin.js
@@ -1,18 +1,19 @@
+import Promise from 'bluebird';
 import R from 'ramda';
 
 
-function appearin(client, e) {
+function appearin(client, evt) {
   const id = Math.random().toString().replace('.', '').slice(0, 10);
   const url = `https://appear.in/${id}`;
 
   // If no mentions, send link back to channel.
-  if (!e.message.mentions.length) return e.message.channel.sendMessage(url);
+  if (!evt.message.mentions.length) return Promise.resolve(url);
 
   // Send url back to author and mentioned users
-  client.Users.get(e.message.author.id).openDM().then(dm => dm.sendMessage(url));
+  client.Users.get(evt.message.author.id).openDM().then(dm => dm.sendMessage(url));
   R.forEach(user => {
-    client.Users.get(user.id).openDM().then(dm => dm.sendMessage(`${e.message.author.username} would like you to join a videocall/screenshare.\n${url}`));
-  }, e.message.mentions);
+    client.Users.get(user.id).openDM().then(dm => dm.sendMessage(`${evt.message.author.username} would like you to join a videocall/screenshare.\n${url}`));
+  }, evt.message.mentions);
 }
 
 export default {

--- a/src/commands/useful/join.js
+++ b/src/commands/useful/join.js
@@ -19,8 +19,8 @@ const permissions = [
 const permission_value = R.sum(R.map(parseInt, permissions));
 const join_link = `https://discordapp.com/oauth2/authorize?&client_id=${nconf.get('CLIENT_ID')}&scope=bot&permissions=${permission_value}`;
 
-function joinServer(client, e, suffix, lang) {
-  e.message.reply(`${T('join_link', lang)}\n${join_link}`);
+function joinServer(client, evt, suffix, lang) {
+  evt.message.reply(`${T('join_link', lang)}\n${join_link}`);
 }
 
 export default {

--- a/src/commands/useful/pastebin.js
+++ b/src/commands/useful/pastebin.js
@@ -3,21 +3,14 @@ import nconf from 'nconf';
 import R from 'ramda';
 import _request from 'request';
 
-import sentry from '../../sentry';
 import T from '../../translate';
 
 
 const request = Promise.promisify(_request);
 
-function makePaste(client, e, paste, lang) {
-  if (!nconf.get('PASTEBIN_KEY')) {
-    return e.message.channel.sendMessage(T('pastebin_setup', lang));
-  }
-
-  if (!paste) {
-    e.message.channel.sendMessage(T('pastebin_usage', lang));
-    return;
-  }
+function makePaste(client, evt, paste, lang) {
+  if (!nconf.get('PASTEBIN_KEY')) return Promise.resolve(T('pastebin_setup', lang));
+  if (!paste) return Promise.resolve(T('pastebin_usage', lang));
 
   const options = {
     url: 'http://pastebin.com/api/api_post.php',
@@ -29,13 +22,7 @@ function makePaste(client, e, paste, lang) {
     }
   };
 
-  request(options)
-    .then(R.prop('body'))
-    .then(text => e.message.channel.sendMessage(text))
-    .catch(err => {
-      sentry(err, 'pastebin');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+  return request(options).then(R.prop('body'));
 }
 
 export default {

--- a/src/commands/useful/unshorten.js
+++ b/src/commands/useful/unshorten.js
@@ -1,22 +1,15 @@
+import Promise from 'bluebird';
 import T from '../../translate';
 
-const uu = require('url-unshort')({nesting: 3});
+const uu = Promise.promisifyAll(require('url-unshort')({nesting: 3}));
 
 
-function unshorten(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(T('unshorten_usage', lang));
-    return;
-  }
-
-  uu.expand(suffix, (err, url) => {
-    if (err) throw err;
-    if (url) {
-      e.message.channel.sendMessage(`Original url is:\n${url}`);
-    } else {
-      e.message.channel.sendMessage('This url can\'t be expanded.');
-    }
-  });
+function unshorten(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(T('unshorten_usage', lang));
+  return uu.expandAsync(suffix)
+    .tap(url => {
+      if (!url) return 'This url can\'t be expanded.';
+    });
 }
 
 export default {

--- a/src/commands/useful/urban.js
+++ b/src/commands/useful/urban.js
@@ -1,23 +1,23 @@
+import Promise from 'bluebird';
 import urbanQuery from 'urban';
 
 import T from '../../translate';
 
 
-function urban(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(T('urban_usage', lang));
-    return;
-  }
-  urbanQuery(suffix).first((json) => {
-    if (json) {
-      const definition = `${json.word}: ${json.definition}
-:arrow_up: ${json.thumbs_up}   :arrow_down: ${json.thumbs_down}
+function urban(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(T('urban_usage', lang));
 
-Example: ${json.example}`;
-      e.message.channel.sendMessage(definition);
-    } else {
-      e.message.channel.sendMessage(`${T('urban_error', lang)}: ${suffix}`);
-    }
+  return new Promise(resolve => {
+    urbanQuery(suffix).first((json) => {
+      if (json) {
+        resolve(`${json.word}: ${json.definition}
+  :arrow_up: ${json.thumbs_up}   :arrow_down: ${json.thumbs_down}
+
+  Example: ${json.example}`);
+      } else {
+        resolve(`${T('urban_error', lang)}: ${suffix}`);
+      }
+    });
   });
 }
 

--- a/src/commands/useful/wiki.js
+++ b/src/commands/useful/wiki.js
@@ -1,21 +1,18 @@
-import R from 'ramda';
+import Promise from 'bluebird';
 import Wiki from 'wikijs';
 
 import T from '../../translate';
 
 
-function wiki(client, e, suffix, lang) {
-  if (!suffix) {
-    e.message.channel.sendMessage(T('wiki_usage', lang));
-    return;
-  }
-  new Wiki().search(suffix, 1).then(data => {
-    new Wiki().page(data.results[0]).then(page => {
-      page.summary().then(summary => {
-        const sum_text = summary.toString().split('\n');
-        R.forEach(paragraph => {
-          e.message.channel.sendMessage(paragraph);
-        }, sum_text);
+function wiki(client, evt, suffix, lang) {
+  if (!suffix) return Promise.resolve(T('wiki_usage', lang));
+
+  return new Promise(resolve => {
+    new Wiki().search(suffix, 1).then(data => {
+      new Wiki().page(data.results[0]).then(page => {
+        page.summary().then(summary => {
+          resolve(summary.toString().split('\n'));
+        });
       });
     });
   });

--- a/src/commands/useful/wiki.js
+++ b/src/commands/useful/wiki.js
@@ -11,6 +11,7 @@ function wiki(client, evt, suffix, lang) {
     new Wiki().search(suffix, 1).then(data => {
       new Wiki().page(data.results[0]).then(page => {
         page.summary().then(summary => {
+          if (!summary) return resolve(T('wiki_error', lang));
           resolve(summary.toString().split('\n'));
         });
       });

--- a/src/commands/useful/youtube.js
+++ b/src/commands/useful/youtube.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import nconf from 'nconf';
 import YoutubeNode from 'youtube-node';
 
@@ -7,28 +8,19 @@ import T from '../../translate';
 const youtube = new YoutubeNode();
 youtube.setKey(nconf.get('YOUTUBE_API_KEY'));
 youtube.addParam('type', 'video,playlist');
+const searchYoutube = Promise.promisify(youtube.search);
 
-function search(client, e, suffix, lang) {
-  if (!nconf.get('YOUTUBE_API_KEY')) {
-    e.message.channel.sendMessage(T('youtube_setup', lang));
-    return;
-  }
+function search(client, evt, suffix, lang) {
+  if (!nconf.get('YOUTUBE_API_KEY')) return Promise.resolve(T('youtube_setup', lang));
+  if (!suffix) return Promise.resolve(T('youtube_usage', lang));
 
-  if (!suffix) {
-    e.message.channel.sendMessage(T('youtube_usage', lang));
-    return;
-  }
-
-  youtube.search(suffix, 1, (err, result) => {
-    if (err) console.log(err);
-    if (!result || !result.items || result.items.length < 1) {
-      e.message.channel.sendMessage(`${T('youtube_error', lang)}: ${suffix}`);
-    } else {
+  return searchYoutube(suffix, 1)
+    .then(result => {
+      if (!result || !result.items || result.items.length < 1) return `${T('youtube_error', lang)}: ${suffix}`;
       const id_obj = result.items[0].id;
-      if (id_obj.playlistId) return e.message.channel.sendMessage(`https://www.youtube.com/playlist?list=${id_obj.playlistId}`);
-      e.message.channel.sendMessage(`http://www.youtube.com/watch?v=${id_obj.videoId}`);
-    }
-  });
+      if (id_obj.playlistId) return `https://www.youtube.com/playlist?list=${id_obj.playlistId}`;
+      return `http://www.youtube.com/watch?v=${id_obj.videoId}`;
+    });
 }
 
 export default {

--- a/src/commands/user.js
+++ b/src/commands/user.js
@@ -1,13 +1,12 @@
 import R from 'ramda';
 
-import sentry from '../sentry';
 import { setUserLang } from '../redis';
 import T, { langs } from '../translate';
 
 const lang_defs = require('../data/lang_defs.json');
 
 
-function setLang(client, e, suffix) {
+function setLang(client, evt, suffix) {
   let lang = suffix.toLowerCase().trim();
 
   if (lang_defs[lang]) lang = lang_defs[lang];
@@ -20,17 +19,11 @@ function setLang(client, e, suffix) {
     }, R.keys(lang_defs));
 
     const langs = R.join('\n', R.map(R.join(', '), R.values(lang_options)));
-    return e.message.channel.sendMessage(`${T('accepted_languages', 'en')}:\n\n**${langs}**`);
+    return evt.message.channel.sendMessage(`${T('accepted_languages', 'en')}:\n\n**${langs}**`);
   }
 
-  setUserLang(e.message.author.id, lang)
-    .then(() => {
-      e.message.reply(`${T('hello', lang)}!`);
-    })
-    .catch(err => {
-      sentry(err, 'user', 'setlang');
-      e.message.channel.sendMessage(`Error: ${err.message}`);
-    });
+  return setUserLang(evt.message.author.id, lang)
+    .then(() => `${T('hello', lang)}!`);
 }
 
 export default {

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -8,7 +8,7 @@ import R from 'ramda';
 
 
 // Initialize PhantomJS
-let options = {
+const options = {
   phantomPath: phantom_path,
   injectJquery: false
 };

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -5,7 +5,6 @@ import raven from 'raven';
 let client = {
   captureError: (err, options) => {
     if (options.tags && options.tags.source && !err.source) err.source = options.tags.source;
-    if (options.tags && options.tags.method && !err.method) err.method = options.tags.method;
     console.error(err.stack || err);
   }
 };
@@ -27,13 +26,13 @@ if (nconf.get('NODE_ENV') === 'production' && nconf.get('SENTRY_DSN')) {
   });
 }
 
-export default function captureError(err, source, method) {
+export default function captureError(err, source) {
   const options = {
-    tags: { source, method }
+    tags: {source}
   };
 
-  if (source && !method) options.tags.method = source;
   if (err.level) options.level = err.level;
+  if (err.level && err.level === 'warning') return;
 
   client.captureError(err, options);
 }


### PR DESCRIPTION
![](https://i.imgflip.com/12pnn1.jpg)

PR merges in to the `Rewrite` branch. Will make contributing easier as contributors will not need to know how our DiscordJS node module works, and instead just knows to return a promise. Also greatly cleans up code, and will make fixing tests much easier.

- Returns promises for all methods instead of the methods sending messages back to Discord themselves. All messages to Discord are handled in `index.js` `callCmd`.
- Rename `e` to `evt`
- Remove unused arguments from methods.