### PR TITLE
Cluster Rework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@ dist/
 tests/
 web/css/
 web/views/*.marko.js
+
+.env
+sharding.yml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ dist/
 
 web/css
 *.marko.js
+
+# Sharding testing
+.env
+sharding.yml

--- a/scripts/sharding/dev.js
+++ b/scripts/sharding/dev.js
@@ -3,10 +3,9 @@ import R from 'ramda';
 import path from 'path';
 
 const root_dir = path.join(__dirname, '../../');
-const total_shards = 4;
+const total_shards = 6;
 
 R.forEach(num => {
-  num -= 1;
   const instance = spawn('npm', ['run', 'dev-nodebug'], {
     cwd: root_dir,
     env: R.merge(process.env, {
@@ -28,4 +27,4 @@ R.forEach(num => {
   instance.on('close', (code) => {
     console.log(`Instance number ${code} process exited with code ${code}`);
   });
-}, R.range(1, total_shards + 1));
+}, R.range(0, total_shards));

--- a/src/discord.js
+++ b/src/discord.js
@@ -1,0 +1,198 @@
+import Promise from 'bluebird';
+import Discordie from 'discordie';
+import nconf from 'nconf';
+import R from 'ramda';
+
+import commands from './commands';
+import datadog from './datadog';
+import logger from './logger';
+import sentry from './sentry';
+
+import { startPortalTimeouts, startPortalIntervals } from './portals';
+import {
+  getMessageTTL,
+  setMessageTTL,
+  getUserLang,
+  subscriber,
+  publisher,
+  ee
+} from './redis';
+
+
+// Init
+let client;
+let initialized = false;
+
+
+function callCmd(cmd, name, client, evt, suffix) {
+  logger.cmd(name, suffix);
+  datadog(`cmd.${name}`, 1);
+
+  function processEntry(entry) {
+    // If string or number, send as a message
+    if (R.is(String, entry) || R.is(Number, entry)) evt.message.channel.sendMessage(entry)
+      .catch((err, res) => {
+        err.res = res;
+        sentry(err, 'discordie.sendMessage');
+      });
+    // If buffer, send as a file, with a default name
+    if (Buffer.isBuffer(entry)) evt.message.channel.uploadFile(entry, 'file.png')
+      .catch((err, res) => {
+        err.res = res;
+        sentry(err, 'discordie.uploadFile');
+      });
+    // If it's an object that contains key 'upload', send file with an optional file name
+    // This works for both uploading local files and buffers
+    if (R.is(Object, entry) && entry.upload) evt.message.channel.uploadFile(entry.upload, entry.filename)
+      .catch((err, res) => {
+        err.res = res;
+        sentry(err, 'discordie.uploadFile');
+      });
+  }
+
+  const user_id = evt.message.author.id;
+  const start_time = new Date().getTime();
+  getMessageTTL(user_id).then(exists => {
+    // If a user is trying to spam messages above the set TTL time, then skip.
+    if (exists) return;
+    setMessageTTL(user_id);
+
+    return getUserLang(user_id).then(lang => {
+      const cmd_return = cmd(client, evt, suffix, lang);
+
+      // All command returns must be a bluebird promise.
+      if (cmd_return instanceof Promise) {
+        return cmd_return.then(res => {
+          const execution_time = new Date().getTime() - start_time;
+          datadog(`cmd_execution_time.${name}`, execution_time);
+          // If null, don't do anything.
+          if (!res) return logger.warn(`Command ${name} didn't return anything. Suffix: ${suffix}`);
+          // If it's an array, process each entry.
+          if (R.is(Array, res)) return R.forEach(processEntry, res);
+          // Process single entry
+          processEntry(res);
+        })
+        .catch(err => {
+          sentry(err, name);
+          evt.message.channel.sendMessage(`Error: ${err.message}`);
+        });
+      }
+    });
+  })
+  .catch(err => {
+    sentry(err, name);
+  });
+}
+
+function onMessage(evt) {
+  if (!evt.message) return;
+  if (client.User.id === evt.message.author.id) return;
+
+  // Checks for PREFIX
+  if (evt.message.content[0] === nconf.get('PREFIX')) {
+    const command = evt.message.content.toLowerCase().split(' ')[0].substring(1);
+    const suffix = evt.message.content.substring(command.length + 2);
+    const cmd = commands[command];
+
+    if (cmd) callCmd(cmd, command, client, evt, suffix);
+    return;
+  }
+
+  // Checks if bot was mentioned
+  if (client.User.isMentioned(evt.message)) {
+    const msg_split = evt.message.content.split(' ');
+
+    // If bot was mentioned without a command, then skip.
+    if (!msg_split[1]) return;
+
+    const suffix = R.join(' ', R.slice(2, msg_split.length, msg_split));
+    let cmd_name = msg_split[1].toLowerCase();
+    if (cmd_name[0] === nconf.get('PREFIX')) cmd_name = cmd_name.slice(1);
+    const cmd = commands[cmd_name];
+
+    if (cmd) callCmd(cmd, cmd_name, client, evt, suffix);
+    return;
+  }
+
+  // Check personal messages
+  if (evt.message.channel.isPrivate) {
+    // Handle invite links
+    if (evt.message.content.indexOf('https://discord.gg/') > -1 || evt.message.content.indexOf('https://discordapp.com/invite/') > -1) {
+      return commands.join(client, evt, evt.message.content);
+    }
+
+    const msg_split = evt.message.content.split(' ');
+    const suffix = R.join(' ', R.slice(1, msg_split.length, msg_split));
+    const cmd_name = msg_split[0].toLowerCase();
+    const cmd = commands[cmd_name];
+
+    if (cmd) callCmd(cmd, cmd_name, client, evt, suffix);
+    return;
+  }
+}
+
+function connect() {
+  if (!nconf.get('TOKEN') || !nconf.get('CLIENT_ID')) {
+    logger.error('Please setup TOKEN and CLIENT_ID in config.js to use Gravebot');
+    process.exit(1);
+  }
+
+  client.connect({token: nconf.get('TOKEN')});
+}
+
+function forceFetchUsers() {
+  logger.info('Force fetching users');
+  client.Users.fetchMembers();
+}
+
+if (nconf.get('SHARDING')) {
+  ee.on('cmd', message => {
+    const { channel_name, instance, request: { cmd, suffix, lang } } = JSON.parse(message);
+    if (instance === nconf.get('SHARD_NUMBER')) return;
+
+    commands[cmd](client, {}, suffix, lang, true)
+      .then(results => {
+        publisher.publish(channel_name, JSON.stringify({instance: nconf.get('SHARD_NUMBER'), results}));
+      });
+  });
+  subscriber.subscribe('cmd');
+}
+
+// Start connects to discord and starts receiving messages. It also emits to a shard pub/sub to notifiy it's booted if
+export function start() {
+  const discordie_options = {};
+  if (nconf.get('SHARDING')) {
+    discordie_options.shardCount = Number(nconf.get('SHARD_COUNT'));
+    discordie_options.shardId = Number(nconf.get('SHARD_NUMBER'));
+    logger.info(`Starting shard ${discordie_options.shardId}`);
+  }
+
+  client = new Discordie(discordie_options);
+
+  // Listen for events on Discord
+  client.Dispatcher.on('GATEWAY_READY', () => {
+    logger.info(`Started successfully. Connected to ${client.Guilds.length} servers.`);
+    setTimeout(forceFetchUsers, 45000);
+
+    if (!initialized) {
+      initialized = true;
+      startPortalTimeouts(client);
+
+      client.Dispatcher.on('MESSAGE_CREATE', onMessage);
+      client.Dispatcher.on('MESSAGE_UPDATE', onMessage);
+      if (nconf.get('SHARDING')) {
+        subscriber.subscribe('active_shard');
+        publisher.publish('shard_done', discordie_options.shardId);
+      }
+    }
+  });
+
+  client.Dispatcher.on('DISCONNECTED', err => {
+    logger.warn('Disconnected. Attempting to reconnect...');
+    sentry(err, 'discord');
+    setTimeout(connect, 2000);
+  });
+
+  startPortalIntervals(client);
+  connect();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,187 +1,43 @@
-import Promise from 'bluebird';
-import Discordie from 'discordie';
+import { cpus } from 'os';
 import nconf from 'nconf';
 import R from 'ramda';
-
 import './init-config';
 import './express';
 import './phantom';
 
-import commands from './commands';
-import datadog from './datadog';
-import logger from './logger';
+import { start } from './discord';
+import { subscriber, publisher, ee, waitForConnections } from './redis';
 import sentry from './sentry';
-
-import { startPortalIntervals, startPortalTimeouts } from './portals';
-import { createDuplicateClient, getMessageTTL, setMessageTTL, getUserLang } from './redis';
+import logger from './logger';
 
 
-// Init
-const discordie_options = {};
+// With sharding enabled, each instance on a machine will boot (CPU-COUNT - 1) concurrently,
+// leaving 1 CPU available for other system process'. When a shard has booted, it'll emit to a redis pub/sub
+// to notify the other shards it's finished and to begin booting the next in line.
+// Before booting, a redis message is emited to see if another instance is alive meaning a cluster has already been started,
+// and then skips the queuing process and boots.
 if (nconf.get('SHARDING')) {
-  discordie_options.shardCount = Number(nconf.get('SHARD_COUNT'));
-  discordie_options.shardId = Number(nconf.get('SHARD_NUMBER'));
-}
+  const cpu_count = cpus().length;
+  const concurrency = cpu_count === 1 ? 1 : cpu_count - 1; // Leave 1 CPU available for other system processing.
+  const shard_number = Number(nconf.get('SHARD_NUMBER'));
 
-const client = new Discordie(discordie_options);
-let initialized = false;
-
-
-function callCmd(cmd, name, client, evt, suffix) {
-  logger.cmd(name, suffix);
-  datadog(`cmd.${name}`, 1);
-
-  function processEntry(entry) {
-    // If string or number, send as a message
-    if (R.is(String, entry) || R.is(Number, entry)) evt.message.channel.sendMessage(entry)
-      .catch((err, res) => {
-        err.res = res;
-        sentry(err, 'discordie.sendMessage');
-      });
-    // If buffer, send as a file, with a default name
-    if (Buffer.isBuffer(entry)) evt.message.channel.uploadFile(entry, 'file.png')
-      .catch((err, res) => {
-        err.res = res;
-        sentry(err, 'discordie.uploadFile');
-      });
-    // If it's an object that contains key 'upload', send file with an optional file name
-    // This works for both uploading local files and buffers
-    if (R.is(Object, entry) && entry.upload) evt.message.channel.uploadFile(entry.upload, entry.filename)
-      .catch((err, res) => {
-        err.res = res;
-        sentry(err, 'discordie.uploadFile');
-      });
-  }
-
-  const user_id = evt.message.author.id;
-  const start_time = new Date().getTime();
-  getMessageTTL(user_id).then(exists => {
-    // If a user is trying to spam messages above the set TTL time, then skip.
-    if (exists) return;
-    setMessageTTL(user_id);
-
-    return getUserLang(user_id).then(lang => {
-      const cmd_return = cmd(client, evt, suffix, lang);
-
-      // All command returns must be a bluebird promise.
-      if (cmd_return instanceof Promise) {
-        return cmd_return.then(res => {
-          const execution_time = new Date().getTime() - start_time;
-          datadog(`cmd_execution_time.${name}`, execution_time);
-          // If null, don't do anything.
-          if (!res) return logger.warn(`Command ${name} didn't return anything. Suffix: ${suffix}`);
-          // If it's an array, process each entry.
-          if (R.is(Array, res)) return R.forEach(processEntry, res);
-          // Process single entry
-          processEntry(res);
-        })
-        .catch(err => {
-          sentry(err, name);
-          evt.message.channel.sendMessage(`Error: ${err.message}`);
+  waitForConnections()
+    .then(() => publisher.pubsubAsync('NUMSUB', 'active_shard'))
+    .then(R.nth(1))
+    .then(active_shards => {
+      if (!active_shards && shard_number > (concurrency - 1)) {
+        logger.info('Queueing up to boot');
+        ee.on('shard_done', shard_id => {
+          // TODO: Shards wait for others to boot even if on other systems.
+          // This needs to also include a system check to continue starting.
+          if ((Number(shard_id) + 1) === shard_number) start();
         });
+        subscriber.subscribe('shard_done');
+      } else {
+        start();
       }
-    });
-  })
-  .catch(err => {
-    sentry(err, name);
-  });
+    })
+    .catch(err => sentry(err));
+} else {
+  start();
 }
-
-function onMessage(evt) {
-  if (!evt.message) return;
-  if (client.User.id === evt.message.author.id) return;
-
-  // Checks for PREFIX
-  if (evt.message.content[0] === nconf.get('PREFIX')) {
-    const command = evt.message.content.toLowerCase().split(' ')[0].substring(1);
-    const suffix = evt.message.content.substring(command.length + 2);
-    const cmd = commands[command];
-
-    if (cmd) callCmd(cmd, command, client, evt, suffix);
-    return;
-  }
-
-  // Checks if bot was mentioned
-  if (client.User.isMentioned(evt.message)) {
-    const msg_split = evt.message.content.split(' ');
-
-    // If bot was mentioned without a command, then skip.
-    if (!msg_split[1]) return;
-
-    const suffix = R.join(' ', R.slice(2, msg_split.length, msg_split));
-    let cmd_name = msg_split[1].toLowerCase();
-    if (cmd_name[0] === nconf.get('PREFIX')) cmd_name = cmd_name.slice(1);
-    const cmd = commands[cmd_name];
-
-    if (cmd) callCmd(cmd, cmd_name, client, evt, suffix);
-    return;
-  }
-
-  // Check personal messages
-  if (evt.message.channel.isPrivate) {
-    // Handle invite links
-    if (evt.message.content.indexOf('https://discord.gg/') > -1 || evt.message.content.indexOf('https://discordapp.com/invite/') > -1) {
-      return commands.join(client, evt, evt.message.content);
-    }
-
-    const msg_split = evt.message.content.split(' ');
-    const suffix = R.join(' ', R.slice(1, msg_split.length, msg_split));
-    const cmd_name = msg_split[0].toLowerCase();
-    const cmd = commands[cmd_name];
-
-    if (cmd) callCmd(cmd, cmd_name, client, evt, suffix);
-    return;
-  }
-}
-
-if (nconf.get('SHARDING')) {
-  const pubClient = createDuplicateClient('cmd processor pub');
-  const subClient = createDuplicateClient('cmd processor sub');
-  subClient.on('message', (channel, message) => {
-    const { channel_name, instance, request: { cmd, suffix, lang } } = JSON.parse(message);
-    if (instance === nconf.get('SHARD_NUMBER')) return;
-
-    commands[cmd](client, {}, suffix, lang, true)
-      .then(results => {
-        pubClient.publish(channel_name, JSON.stringify({instance: nconf.get('SHARD_NUMBER'), results}));
-      });
-  });
-  subClient.subscribe('cmd');
-}
-
-function connect() {
-  if (!nconf.get('TOKEN') || !nconf.get('CLIENT_ID')) {
-    logger.error('Please setup TOKEN and CLIENT_ID in config.js to use Gravebot');
-    process.exit(1);
-  }
-
-  client.connect({token: nconf.get('TOKEN')});
-}
-
-function forceFetchUsers() {
-  logger.info('Force fetching users');
-  client.Users.fetchMembers();
-}
-
-// Listen for events on Discord
-client.Dispatcher.on('GATEWAY_READY', () => {
-  logger.info(`Started successfully. Connected to ${client.Guilds.length} servers.`);
-  setTimeout(forceFetchUsers, 45000);
-
-  if (!initialized) {
-    initialized = true;
-    startPortalTimeouts(client);
-
-    client.Dispatcher.on('MESSAGE_CREATE', onMessage);
-    client.Dispatcher.on('MESSAGE_UPDATE', onMessage);
-  }
-});
-
-client.Dispatcher.on('DISCONNECTED', err => {
-  logger.warn('Disconnected. Attempting to reconnect...');
-  sentry(err, 'discord');
-  setTimeout(connect, 2000);
-});
-
-startPortalIntervals(client);
-connect();


### PR DESCRIPTION
## Overview

Due to the large user base Gravebot has, the CPU usage on boot can be very high in order to initialize connecting and working with Discord. When attempting to load shards at once on a system with less cores then shards, process' will return `ELIFECYCLE` and crash due to not enough CPU resources to go around. However after initialization the CPU usage is quite low.

This PR adds a delay to the amount of shards that can start at time by the amount of CPU cores minus 1. Every time a shard has completed booting, it emits a message through Redis to begin booting the next shard.

If a shard is to crash, it'll check if at least one shard has been initialized, otherwise it will think it's going through boot with the rest of the cluster and wait in the queue.

## Compose example

Due to how docker-compose works, and the fact that each shard needs to know what `shard_id` it is supposed to be using, our compose file looks like this. I don't believe we'd have these problems with Kubernetes, which is something I'm moving towards in the future.

```yaml
redis:
  image: redis:latest
  restart: always
  ports:
    - 6379:6379
  environment:
    REDIS_USER: redis
    REDIS_DATA_DIR: /var/lib/redis
    REDIS_LOG_DIR: /var/log/redis
  volumes:
    - /srv/docker/redis:/var/lib/redis

gravebot-0:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 0

gravebot-1:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 1

gravebot-2:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 2

gravebot-3:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 3

gravebot-4:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 4

gravebot-5:
  image: gravebot/gravebot:latest
  links:
    - redis
  restart: always
  env_file: .env
  environment:
    SHARD_NUMBER: 5
```

## Redis

This PR also cleans up how we use redis pub/sub clients by sharing those clients across the entire application, instead of creating instances of each task.