### PR TITLE
Try and make the bot python for python users

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "concurrently": "^2.1.0",
     "diacritics": "^1.2.3",
     "didyoumean": "^1.2.1",
-    "discordie": "^0.7.2",
+    "discordie": "git+https://github.com/qeled/discordie#571cde8c975e1374ab9fcc95ceb805bcc9b27d40",
     "dogapi": "^2.3.0",
     "entities": "^1.1.1",
     "express": "^4.13.4",


### PR DESCRIPTION
I would like to say to make the bot a python so people with python 3.4/python 3.5 so they can run it if it's hard for them to use JS.

- TomCreeper
    (Creeper Development Team #Leader#)
