### PR TITLE
Fix sharding

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "concurrently": "^2.1.0",
     "diacritics": "^1.2.3",
     "didyoumean": "^1.2.1",
-    "discordie": "^0.8.0",
+    "discordie": "^0.10.0",
     "dogapi": "^2.3.0",
     "entities": "^1.1.1",
     "express": "^4.13.4",

--- a/src/commands/info/servers.js
+++ b/src/commands/info/servers.js
@@ -12,6 +12,7 @@ function servers(client, evt, suffix, lang, json) {
     return getShardsCmdResults('servers')
       .then(R.append({results: server_count}))
       .then(R.pluck('results'))
+      .filter(results => !R.isEmpty(results))
       .reduce((sum, res) => R.zipObj(R.keys(res), R.map(key => sum[key] + res[key], R.keys(res))))
       .then(res => `Connected to ${res.guilds} servers, ${res.channels} channels and ${res.users} users.`);
   }

--- a/src/commands/info/uptime.js
+++ b/src/commands/info/uptime.js
@@ -12,12 +12,15 @@ function uptime(client, evt, suffix, lang, json) {
 
   if (nconf.get('SHARDING') && !json) {
     return getShardsCmdResults('uptime')
-      .then(R.append({instance: nconf.get('SHARD_NUMBER'), results: {uptimeh, uptimem, uptimes}}))
-      .then(R.sortBy(R.prop('instance')))
-      .map(({instance, results}) => `Instance ${instance} has been alive for:
+      .then(R.append({shard: nconf.get('SHARD_NUMBER'), results: {uptimeh, uptimem, uptimes}}))
+      .then(R.sortBy(R.prop('shard')))
+      .map(({shard, results}) => {
+        if (!results || R.isEmpty(results)) return `Shard ${shard} isn't live yet.`;
+        return `Shard ${shard} has been alive for:
 ${results.uptimeh} Hours
 ${results.uptimem} Minutes
-${results.uptimes} Seconds`)
+${results.uptimes} Seconds`;
+      })
       .then(R.join('\n\n'));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ import logger from './logger';
 // to notify the other shards it's finished and to begin booting the next in line.
 // Before booting, a redis message is emited to see if another instance is alive meaning a cluster has already been started,
 // and then skips the queuing process and boots.
+
+let skip_queue_timeout;
+let booting = false;
 if (nconf.get('SHARDING')) {
   const cpu_count = cpus().length;
   const concurrency = cpu_count === 1 ? 1 : cpu_count - 1; // Leave 1 CPU available for other system processing.
@@ -28,7 +31,22 @@ if (nconf.get('SHARDING')) {
         ee.on('shard_done', shard_id => {
           // TODO: Shards wait for others to boot even if on other systems.
           // This needs to also include a system check to continue starting.
-          if ((Number(shard_id) + 1) === shard_number) start();
+          shard_id = (Number(shard_id) + 1);
+          if (shard_id === shard_number && !booting) {
+            booting = true;
+            if (skip_queue_timeout) clearTimeout(skip_queue_timeout);
+            start();
+          }
+
+          // If other shards are having some issues booting, skip queue and continue.
+          if ((shard_id + 1) === shard_number && !booting) {
+            logger.info('Setting skipped queue timeout');
+            skip_queue_timeout = setTimeout(() => {
+              logger.info('Previous shard is taking too long to boot. Start booting.');
+              booting = true;
+              start();
+            }, 120000);
+          }
         });
         subscriber.subscribe('shard_done');
       } else {


### PR DESCRIPTION
## Overview

WIP PR to fix sharding boot issues.

- Updated to latest discordie
- Fixed bug where multi shard commands would attempt to access `client` before it was initialized. Shards now return empty objects if the shard isn't booted yet.
- Initial submissions to portals on boot are now only submitted by the last shard. All shards still submit on an interval.
- `!uptime` command now shows if shards are offline.
- Shards will now skip queue if the shard before it takes longer then 2 minutes to boot, assuming something is wrong
- Discordie now attempts to reconnect after 10 seconds rather then 2 to help avoid rate limits