### PR TITLE
Temporary fix for Wolfram

### DIFF
--- a/src/commands/useful/wolfram.js
+++ b/src/commands/useful/wolfram.js
@@ -8,7 +8,7 @@ import T from '../../translate';
 
 function queryWolf(wolf, query) {
   return new Promise((resolve, reject) => {
-    wolf.query(query, (err, results) => {
+    wolf.queryCb(query, (err, results) => {
       if (err) return reject(err);
       return resolve(results);
     });


### PR DESCRIPTION
As per their 0.6.0 docs, `.query` now returns a Promise. `.queryCb` has the old functionality still. Wondered if you guys wanted this as a temporary fix while you sort a permanent one.